### PR TITLE
FrenchApp & Web modification, trying to resolve HTTP500 errors on website

### DIFF
--- a/data.go
+++ b/data.go
@@ -204,12 +204,16 @@ func (dm *DataModel) Save() error {
 		return err
 	}
 
-	var eg errgroup.Group
-	eg.Go(dm.Cache)
+	// var eg errgroup.Group
+	// eg.Go(dm.Cache)
+	// eg.Wait()
+
+	var eg2 errgroup.Group
 	if obj, ok := dm.model.(OnSave); ok {
-		eg.Go(obj.Save)
+		eg2.Go(obj.Save)
 	}
-	return eg.Wait()
+	waitRoutine := eg2.Wait()
+	return waitRoutine
 }
 
 // Context returns the internal net/context


### PR DESCRIPTION
After some research, it seems that the timeouts are due to the code hanging at the eg.Wait(), because dm.Cache sometimes never resolves.

Some tests seem to indicate that commenting out the Cache call resolves the issue. This PR applies this test, hoping that it does indeed fix the issue.